### PR TITLE
Adds a factory fn for main export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "4"
+  - "6"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Build Status](https://travis-ci.org/BeepBoopHQ/slackapp-js.svg)](https://travis-ci.org/BeepBoopHQ/slackapp-js)
+
 # slackapp-js
 A node.js module for Slack App integrations

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slackapp",
   "version": "0.0.6",
   "description": "A module for Slack App integrations",
-  "main": "src/slackapp.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "standard"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+const SlackApp = require('./slackapp')
+
+/**
+ * Initialize a SlackApp, accepts an options object
+ *
+ * Options:
+ * - `app_token`   Slack App token
+ * - `app_user_id` Slack App User ID (who installed the app)
+ * - `bot_token`   Slack App Bot token
+ * - `bot_user_id` Slack App Bot ID
+ * - `convo_store` `string` of type of Conversation store (`memory`, etc.) or `object` implementation
+ * - `error`       Error handler function `(error) => {}`
+ */
+module.exports = (opts) => {
+  let app = new SlackApp(opts)
+
+  return app.init()
+}

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -47,12 +47,19 @@ module.exports = class SlackApp {
     this.onError = opts.error || (() => {})
     this.client = slack
     this.receiver = new Receiver(opts)
+  }
 
+  /**
+   * Initialize app w/ default middleware and receiver listener
+   */
+  init () {
     // call `handle` for each new request
     // TODO: make overridable for testing
     this.receiver.on('message', this._handle.bind(this))
     this.use(this.ignoreBotsMiddleware())
     this.use(this.preprocessConversationMiddleware())
+
+    return this
   }
 
   /**


### PR DESCRIPTION
+ adds a factory fn as main exported module
+ breaks out defaulting of mw and receiver listener to init() fn that is called in the factory fn (makes constructor have less side-effects, easier to test)
+ adds travis cfg and badge (currently just linting)