### PR TITLE
Rename remaining interactive -> action

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -91,10 +91,10 @@ module.exports = class Message {
   }
 
   /**
-   * Use a `response_url` from a Slash command or interactive message
+   * Use a `response_url` from a Slash command or interactive message action
    *
    * Parameters
-   * - `responseUrl` string - URL provided by a Slack interactive message or slash command
+   * - `responseUrl` string - URL provided by a Slack interactive message action or slash command
    * - `input` string or object or Array
    *     * type `object`: raw object that would be past to `chat.postmessage`
    *     * type `string`: text of a message that will be used to construct object sent to `chat.postmessage`

--- a/src/receiver.js
+++ b/src/receiver.js
@@ -27,7 +27,7 @@ module.exports = class Receiver extends EventEmitter {
     self.logfn = {
       'event': self.logEvent.bind(self),
       'command': self.logCommand.bind(self),
-      'action': self.logInteractive.bind(self)
+      'action': self.logAction.bind(self)
     }
   }
 
@@ -43,11 +43,11 @@ module.exports = class Receiver extends EventEmitter {
              this.tokenMiddleware.bind(this),
              bodyParser.urlencoded({extended: true}),
              this.commandHandler.bind(this))
-    app.post('/slack-interactive',
+    app.post('/slack-action',
              this.tokenMiddleware.bind(this),
              bodyParser.urlencoded({extended: true}),
              bodyParser.text({type: '*/*'}),
-             this.interactiveHandler.bind(this))
+             this.actionHandler.bind(this))
     return app
   }
 
@@ -82,7 +82,7 @@ module.exports = class Receiver extends EventEmitter {
     return res.send()
   }
 
-  interactiveHandler (req, res) {
+  actionHandler (req, res) {
     let body = req.body
     if (!body || !body.payload) {
       return res.send('Invalid request: payload missing')
@@ -154,9 +154,9 @@ module.exports = class Receiver extends EventEmitter {
     console.log(cmd.user_id + ' -> ' + cmd.command + ' ' + cmd.text)
   }
 
-  logInteractive (interactive) {
-    if (!interactive) return console.log('Interactive: UNKNOWN')
-    console.log('Interactive:', interactive)
+  logAction (action) {
+    if (!action) return console.log('Action: UNKNOWN')
+    console.log('Action:', action)
   }
 
 }

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -159,7 +159,7 @@ module.exports = class SlackApp {
    * Routes are:
    * - POST `/slack-event`
    * - POST `/slack-command`
-   * - POST `/slack-interactive`
+   * - POST `/slack-action`
    */
 
   attachToExpress (app) {


### PR DESCRIPTION
Renamed remaining references to "interactive" to "action".  This was renamed along the way but these were left over. The default URL endpoint `/slack-interactive` was renamed to `slack-action` too.