### PR TITLE
adds more coverage for SlackApp class

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava",
-    "coverage": "nyc ava"
+    "unit": "ava --verbose",
+    "coverage": "nyc ava --verbose"
   },
   "repository": {
     "type": "git",

--- a/src/message.js
+++ b/src/message.js
@@ -193,7 +193,6 @@ module.exports = class Message {
       found = found || (filter === 'ambient' && this.isAmbient())
       found = found || (filter === 'mention' && this.isMention())
     }
-    console.log('Found', found, messageFilters)
     return found
   }
 

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -95,7 +95,8 @@ module.exports = class SlackApp {
 
   ignoreBotsMiddleware () {
     return (msg, next) => {
-      if (msg.meta.bot_id || msg.meta.user_id === msg.meta.bot_user_id) {
+      // avoid the case where both user_id and bot_user_id not set
+      if (msg.meta.bot_id || (msg.meta.user_id && msg.meta.user_id === msg.meta.bot_user_id)) {
         return
       }
       next()
@@ -278,7 +279,7 @@ module.exports = class SlackApp {
     }
 
     let fn = (msg) => {
-      if (msg.type === 'event' && msg.body.event && msg.body.event.type === 'message') {
+      if (msg.isMessage()) {
         let text = msg.stripDirectMention()
         if (criteria.test(text) && (typeFilter.length === 0 || msg.isAnyOf(typeFilter))) {
           callback(msg, text)


### PR DESCRIPTION
+ Adding 97% coverage for `SlackApp`
+ Enables verbose reporting for tests
+ Replaces redundant logic in `SlackApp.message` w/ call to `msg.isMessage()`
+ Adds a check in `ignoreBotsMiddleware` where `user_id` and `bot_user_id` are both not set.  This condition probably won't occur when everything is setup as usual, but just in case I thought it probably shouldn't treat it as a bot message.
+ Remove `console.log()` stmt
