### PR TITLE
Verify token

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,33 +40,14 @@ A node.js module for Slack App integrations
 # SlackApp
 
   - [SlackApp.use()](#slackappusefnfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.attachToExpress()](#slackappattachtoexpressappobject)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.route()](#slackapproutefnkeystringfnfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.getRoute()](#slackappgetroutefnkeystring)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.match()](#slackappmatchfnfunction)
-  - [Returns `true` if there is a match AND you handled the msg.](#returnstrueifthereisamatchandyouhandledthemsg)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.message()](#slackappmessagecriteriastringtypefilterstringarray)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.event()](#slackappeventcriteriastringregexpcallbackfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.action()](#slackappactioncallbackidstringactionnamecriteriastringregexpcallbackfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [SlackApp.command()](#slackappcommandcommandstringcriteriastringregexpcallbackfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
 
 ## SlackApp.use(fn:function)
 
@@ -154,7 +135,7 @@ A node.js module for Slack App integrations
   - `this` (chainable)
   
   
-  Example `msg` object:
+  Example `msg.body`:
   
 ```js
  {
@@ -228,7 +209,7 @@ A node.js module for Slack App integrations
   - `this` (chainable)
   
   
-  Example `msg` object:
+  Example `msg.body` object:
   
 ```js
   {
@@ -355,9 +336,7 @@ It is generally always passed as `msg`.
 - `body` - the unmodified payload of the original event
 - `meta` - derived or normalized properties and anything appended by middleware.
 
-
 `meta` should at least have these properties
-- ``
 - `app_token` - token for the user for the app
 - `app_user_id` - userID for the user who install ed the app
 - `bot_token` - token for a bot user of the app
@@ -365,46 +344,24 @@ It is generally always passed as `msg`.
     
 
   - [Message.constructor()](#messageconstructortypestringbodyobjectmetaobject)
-  - [Parameters](#parameters)
   - [Message.route()](#messageroutefnkeystringstateobjectsecondstoexpirenumber)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [Message.cancel()](#messagecancel)
   - [Message.say()](#messagesayinputstringobjectarraycallbackfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [Message.respond()](#messagerespondresponseurlstringinputstringobjectarraycallbackfunction)
-  - [Parameters](#parameters)
-  - [Returns](#returns)
   - [Message.isMessage()](#messageismessage)
-  - [Returns `bool` true if `this` is a message event type](#returnsbooltrueifthisisamessageeventtype)
   - [Message.isDirectMention()](#messageisdirectmention)
-  - [Returns `bool` true if `this` is a direct mention](#returnsbooltrueifthisisadirectmention)
   - [Message.isDirectMessage()](#messageisdirectmessage)
-  - [Returns `bool` true if `this` is a direct message](#returnsbooltrueifthisisadirectmessage)
   - [Message.isMention()](#messageismention)
-  - [Returns `bool` true if `this` mentions the bot user](#returnsbooltrueifthismentionsthebotuser)
   - [Message.isAmbient()](#messageisambient)
-  - [Returns `bool` true if `this` is an ambient message](#returnsbooltrueifthisisanambientmessage)
   - [Message.isAnyOf()](#messageisanyofofarray)
-  - [Parameters](#parameters)
-  - [Returns `bool` true if `this` is a message that matches any of the filters](#returnsbooltrueifthisisamessagethatmatchesanyofthefilters)
   - [Message.usersMentioned()](#messageusersmentioned)
-  - [Returns an Array of user IDs](#returnsanarrayofuserids)
   - [Message.channelsMentioned()](#messagechannelsmentioned)
-  - [Returns an Array of channel IDs](#returnsanarrayofchannelids)
   - [Message.subteamGroupsMentioned()](#messagesubteamgroupsmentioned)
-  - [Returns an Array of subteam IDs](#returnsanarrayofsubteamids)
   - [Message.everyoneMentioned()](#messageeveryonementioned)
-  - [Returns `bool` true if `@everyone` was mentioned](#returnsbooltrueifeveryonewasmentioned)
   - [Message.channelMentioned()](#messagechannelmentioned)
-  - [Returns `bool` true if `@channel` was mentioned](#returnsbooltrueifchannelwasmentioned)
   - [Message.hereMentioned()](#messageherementioned)
-  - [Returns `bool` true if `@here` was mentioned](#returnsbooltrueifherewasmentioned)
   - [Message.linksMentioned()](#messagelinksmentioned)
-  - [Returns `Array:string` of URLs of links mentioned in the message](#returnsarraystringofurlsoflinksmentionedinthemessage)
   - [Message.stripDirectMention()](#messagestripdirectmention)
-  - [Returns `string` original `text` of message with a direct mention of the bot](#returnsstringoriginaltextofmessagewithadirectmentionofthebot)
 
 ## Message.constructor(type:string, body:Object, meta:Object)
 

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -61,9 +61,8 @@ fs.writeFileSync(readmePath, updatedReadme)
 
 function formatDoxComments (comments) {
   var buf = []
-  console.log(JSON.stringify(comments))
 
-  comments.forEach(function (comment) {
+  comments.forEach((comment) => {
     if (comment.isPrivate) return
     if (comment.ignore) return
     var ctx = comment.ctx
@@ -83,7 +82,7 @@ function formatDoxComments (comments) {
 
   var code = buf.match(/^( {4}[^\n]+\n*)+/gm) || []
 
-  code.forEach(function (block) {
+  code.forEach((block) => {
     var code = block.replace(/^ {4}/gm, '')
     buf = buf.replace(block, '```js\n' + code.trimRight() + '\n```\n\n')
   })
@@ -92,7 +91,7 @@ function formatDoxComments (comments) {
 }
 
 function toc (str) {
-  return headings(str).map(function (h) {
+  return headings(str).filter((h) => { return h.level <= 2 }).map((h) => {
     var clean = h.title.replace(/\(.*?\)/, '()')
     return '  - [' + clean + '](#' + slug(h.title) + ')'
   }).join('\n')
@@ -103,7 +102,7 @@ function slug (str) {
 }
 
 function headings (str) {
-  return (str.match(/^#+ *([^\n]+)/gm) || []).map(function (str) {
+  return (str.match(/^#+ *([^\n]+)/gm) || []).map((str) => {
     str = str.replace(/^(#+) */, '')
     return {
       title: str,
@@ -116,7 +115,7 @@ function context (comment) {
   var ctx = comment.ctx
   var tags = comment.tags
 
-  var alias = tags.map(function (tag) {
+  var alias = tags.map((tag) => {
     return tag.type === 'alias' && tag.string
   }).filter(Boolean)
 
@@ -136,9 +135,9 @@ function context (comment) {
 }
 
 function params (tags) {
-  return tags.filter(function (tag) {
+  return tags.filter((tag) => {
     return tag.type === 'param'
-  }).map(function (param) {
+  }).map((param) => {
     return param.name + ':' + param.types.join('|')
   }).join(', ')
 }

--- a/src/receiver.js
+++ b/src/receiver.js
@@ -16,6 +16,8 @@ module.exports = class Receiver extends EventEmitter {
     opts = opts || {}
 
     this.debug = opts.debug
+    this.verify_token = opts.verify_token
+
     this.app_token = opts.app_token
     this.app_user_id = opts.app_user_id
     this.bot_token = opts.bot_token
@@ -78,12 +80,26 @@ module.exports = class Receiver extends EventEmitter {
 
   eventHandler (req, res) {
     let body = req.body
+
+    // test verify token
+    if (this.verify_token && this.verify_token !== body.token) {
+      res.status(403).send('Invalid token')
+      return
+    }
+
     this.doEmit('event', body, req.app_details)
     return res.send()
   }
 
   commandHandler (req, res) {
     let body = req.body
+
+    // test verify token
+    if (this.verify_token && this.verify_token !== body.token) {
+      res.status(403).send('Invalid token')
+      return
+    }
+
     this.doEmit('command', body, req.app_details)
     return res.send()
   }
@@ -94,6 +110,13 @@ module.exports = class Receiver extends EventEmitter {
       return res.send('Invalid request: payload missing')
     }
     body = JSON.parse(body.payload)
+
+    // test verify token
+    if (this.verify_token && this.verify_token !== body.token) {
+      res.status(403).send('Invalid token')
+      return
+    }
+
     this.doEmit('action', body, req.app_details)
     return res.send()
   }

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -15,6 +15,7 @@ class SlackApp {
    * Construct a SlackApp, accepts an options object
    *
    * ##### Parameters
+   * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
    * - `opts.app_token`   Slack App token override
    * - `opts.app_user_id` Slack App User ID (who installed the app)
    * - `opts.bot_token`   Slack App Bot token
@@ -33,6 +34,8 @@ class SlackApp {
     this._middleware = []
     this._matchers = []
     this._registry = {}
+
+    this.verify_token = opts.verify_token = opts.verify_token || process.env.SLACK_VERIFY_TOKEN
 
     this.app_token = opts.app_token
     this.app_user_id = opts.app_user_id
@@ -296,7 +299,7 @@ class SlackApp {
    * - `this` (chainable)
    *
    *
-   * Example `msg` object:
+   * Example `msg.body`:
    *
    *    {
    *       "token":"dxxxxxxxxxxxxxxxxxxxx",
@@ -411,7 +414,7 @@ class SlackApp {
    * - `this` (chainable)
    *
    *
-   * Example `msg` object:
+   * Example `msg.body` object:
    *
    *     {
    *        "actions":[


### PR DESCRIPTION
Add verify token checks to the receiver, defaulting to `SLACK_VERIFY_TOKEN` and checking the `body.token` values. If `opts.verify_token` and `SLACK_VERIFY_TOKEN` doesn't exist, don't check.

Also removed the `Returns` and `Parameters` lines from the TOC.