### PR TITLE
Slack challenge

### DIFF
--- a/src/receiver.js
+++ b/src/receiver.js
@@ -87,6 +87,13 @@ module.exports = class Receiver extends EventEmitter {
       return
     }
 
+    // if this is a Slack challenge request, respond with the challenge and
+    // don't emit the event
+    if (body.challenge) {
+      res.send({ challenge: body.challenge })
+      return
+    }
+
     this.doEmit('event', body, req.app_details)
     return res.send()
   }


### PR DESCRIPTION
** this should be merged after the [verify token PR](https://github.com/BeepBoopHQ/slackapp-js/pull/8)

If the receiver event handler receives a challenge request from Slack, respond back with the challenge property. If a `SLACK_VERIFY_TOKEN` was provided, this should be considered first and if the verify tokens don't match, return a `403`.