### PR TITLE
fixes coveralls

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava --verbose  test/*.test.js",
-    "coverage": "nyc ava --verbose test/*.test.js",
-    "lcov": "npm run coverage -- --reporter=lcov",
+    "unit": "ava --verbose",
+    "coverage": "nyc ava --verbose",
+    "lcov": "nyc --reporter lcov ava",
     "docs": "node scripts/docs.js",
-    "coveralls": "./node_modules/.bin/nyc ./node_modules/.bin/ava --reporter=lcov test/*.test.js && cat ./coverage/lcov.info | coveralls"
+    "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not sure why it worked, then stopped, but the only way I could get coveralls to work was to remove flags passed into npm script calls in scripts themselves, and move the reporter flag before the ava call.