### PR TITLE
Receiver metadata load

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,13 +526,14 @@ It is generally always passed as `msg`.
 
 # Contributing
 
-We adore contributions. Please include the details of the proposed changes in a Pull Request and ensure `npm run test` pass. 👻
+We adore contributions. Please include the details of the proposed changes in a Pull Request and ensure `npm test` pass. 👻
 
 ### Scripts
 - `npm test` - runs linter and tests with coverage
 - `npm run unit` - runs unit tests without coverage
 - `npm run lint` - just runs JS standard linter
 - `npm run coverage` - runs tests with coverage
+- `npm run lcov` - runs tests with coverage and output lcov report
 - `npm run docs` - regenerates API docs in this README.md
 
 # License

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava --verbose -T 10000",
-    "coverage": "nyc ava --verbose -T 10000",
-    "lcov": "nyc --reporter lcov ava -T 10000",
+    "unit": "ava --verbose -T 30000",
+    "coverage": "nyc ava --verbose -T 30000",
+    "lcov": "nyc --reporter lcov ava -T 30000",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
     "unit": "ava --verbose",
-    "coverage": "nyc ava --verbose",
+    "coverage": "nyc --check-coverage --statements 95 ava --verbose",
     "lcov": "nyc --reporter lcov ava",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava --verbose",
-    "coverage": "nyc ava --verbose",
-    "lcov": "nyc --reporter lcov ava",
+    "unit": "ava --verbose -T 10000",
+    "coverage": "nyc ava --verbose -T 10000",
+    "lcov": "nyc --reporter lcov ava -T 10000",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "lint": "standard",
-    "unit": "ava --verbose -T 30000",
-    "coverage": "nyc ava --verbose -T 30000",
-    "lcov": "nyc --reporter lcov ava -T 30000",
+    "unit": "ava --verbose",
+    "coverage": "nyc ava --verbose",
+    "lcov": "nyc --reporter lcov ava",
     "docs": "node scripts/docs.js",
     "coveralls": "npm run lcov && cat ./coverage/lcov.info | coveralls"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SlackApp = require('./slackapp')
 
 /**

--- a/src/message.js
+++ b/src/message.js
@@ -197,6 +197,7 @@ class Message {
   }
 
   // TODO: PR this into smallwins/slack, below inspired by https://github.com/smallwins/slack/blob/master/src/_exec.js#L20
+  /* istanbul ignore next */
   _request (responseUrl, input, callback) {
     request({
       uri: responseUrl,

--- a/src/receiver.js
+++ b/src/receiver.js
@@ -7,8 +7,9 @@ const Message = require('./message')
 const ParseEvent = require('./receiver/middleware/parse-event')
 const ParseCommand = require('./receiver/middleware/parse-command')
 const ParseAction = require('./receiver/middleware/parse-action')
-const LookupTokens = require('./receiver/middleware/tokens')
+const LookupTokens = require('./receiver/middleware/lookup-tokens')
 const VerifyToken = require('./receiver/middleware/verify-token')
+const SSLCheck = require('./receiver/middleware/ssl-check')
 
 /**
  * Receives HTTP requests with Events, Slash Commands, and Actions
@@ -17,65 +18,74 @@ const VerifyToken = require('./receiver/middleware/verify-token')
 module.exports = class Receiver extends EventEmitter {
   constructor (opts) {
     super()
-    let self = this
     opts = opts || {}
 
     this.debug = opts.debug
     this.verify_token = opts.verify_token
-    this.tokensLookup = opts.tokensLookup || LookupTokens(opts)
+    this.tokens_lookup = opts.tokens_lookup || LookupTokens(opts)
 
     // record all events to a JSON line delimited file if record is set
     if (opts.record) {
-      self.started = Date.now()
+      this.started = Date.now()
       fs.writeFileSync(opts.record, '')
-      self.on('message', (obj) => {
+      this.on('message', (obj) => {
         fs.appendFile(opts.record, JSON.stringify(Object.assign({}, obj, { delay: Date.now() - this.started })) + '\n')
       })
     }
 
-    self.logfn = {
-      'event': self.logEvent.bind(self),
-      'command': self.logCommand.bind(self),
-      'action': self.logAction.bind(self)
+    this.logfn = {
+      'event': this.logEvent.bind(this),
+      'command': this.logCommand.bind(this),
+      'action': this.logAction.bind(this)
     }
   }
 
   /**
    * Attach receiver HTTP route to an express app
    */
-  attachToExpress (app, options) {
-    options = Object.assign({
-      event: true,
-      command: true,
-      action: true
-    }, options || {})
+  attachToExpress (app, opts) {
+    let defaults = {
+      event: '/slackapp/event',
+      command: '/slackapp/command',
+      action: '/slackapp/action'
+    }
+    let options = opts || defaults
+
+    // replace any `true` values w/ default paths
+    Object.keys(options).forEach((type) => {
+      options[type] === true ? defaults[type] : options[type]
+    })
 
     let emitHandler = this.emitHandler.bind(this)
     let verifyToken = VerifyToken(this.verify_token)
+    let sslCheck = SSLCheck()
 
     if (options.event) {
-      app.post('slackapp/event',
+      app.post(options.event,
         ParseEvent(),
+        sslCheck,
         verifyToken,
-        this.tokensLookup,
+        this.tokens_lookup,
         emitHandler
       )
     }
 
     if (options.command) {
-      app.post('/slackapp/command',
+      app.post(options.command,
         ParseCommand(),
+        sslCheck,
         verifyToken,
-        this.tokensLookup,
+        this.tokens_lookup,
         emitHandler
       )
     }
 
     if (options.action) {
-      app.post('/slackapp/action',
+      app.post(options.action,
         ParseAction(),
+        sslCheck,
         verifyToken,
-        this.tokensLookup,
+        this.tokens_lookup,
         emitHandler
       )
     }
@@ -96,112 +106,7 @@ module.exports = class Receiver extends EventEmitter {
 
     let msg = new Message(message.type, message.body, message.meta)
     this.emit('message', msg)
-  }
-
-  tokenMiddleware (req, res, next) {
-    if (req.headers['bb-error']) {
-      console.error('Event: Error: ' + req.headers['bb-error'])
-      return res.send(req.headers['bb-error'])
-    }
-    req.app_details = {
-      // token for the user for the app
-      app_token: req.headers['bb-slackaccesstoken'] || this.app_token,
-      // userID for the user who install ed the app
-      app_user_id: req.headers['bb-slackuserid'] || this.app_user_id,
-      // token for a bot user of the app
-      bot_token: req.headers['bb-slackbotaccesstoken'] || this.bot_token,
-      // userID of the bot user of the app
-      bot_user_id: req.headers['bb-slackbotuserid'] || this.bot_user_id
-    }
-
-    next()
-  }
-
-  eventHandler (req, res) {
-    let body = req.body
-
-    // test verify token
-    // if (this.verify_token && this.verify_token !== body.token) {
-    //   res.status(403).send('Invalid token')
-    //   return
-    // }
-
-    // if this is a Slack challenge request, respond with the challenge and
-    // don't emit the event
-    // if (body.challenge) {
-    //   res.send({ challenge: body.challenge })
-    //   return
-    // }
-
-    this.doEmit('event', body, req.app_details)
-    return res.send()
-  }
-
-  commandHandler (req, res) {
-    let body = req.body
-
-    // test verify token
-    // if (this.verify_token && this.verify_token !== body.token) {
-    //   res.status(403).send('Invalid token')
-    //   return
-    // }
-
-    this.doEmit('command', body, req.app_details)
-    return res.send()
-  }
-
-  actionHandler (req, res) {
-    // let body = req.body
-    // if (!body || !body.payload) {
-    //   return res.send('Invalid request: payload missing')
-    // }
-    // body = JSON.parse(body.payload)
-
-    // test verify token
-    // if (this.verify_token && this.verify_token !== body.token) {
-    //   res.status(403).send('Invalid token')
-    //   return
-    // }
-
-    this.doEmit('action', body, req.app_details)
-    return res.send()
-  }
-
-  doEmit (type, body, appDetails) {
-    if (!body || body && body.ssl_check) {
-      return
-    }
-
-    if (this.debug && this.logfn[type]) this.logfn[type](body)
-    const meta = Object.assign({}, this.parseMeta(type, body), appDetails)
-    let msg = new Message(type, body, meta)
-    this.emit('message', msg)
-  }
-
-  parseMeta (type, body) {
-    switch (type) {
-      case 'event':
-        return {
-          user_id: body.event.user,
-          bot_id: body.event.bot_id,
-          channel_id: body.event.channel,
-          team_id: body.team_id
-        }
-      case 'command':
-        return {
-          user_id: body.user_id,
-          channel_id: body.channel_id,
-          team_id: body.team_id
-        }
-      case 'action':
-        return {
-          user_id: body.user.id,
-          channel_id: body.channel.id,
-          team_id: body.team.id
-        }
-      default:
-        return {}
-    }
+    res.send()
   }
 
   logEvent (evt) {

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -52,7 +52,7 @@ module.exports = class Receiver extends EventEmitter {
 
     // replace any `true` values w/ default paths
     Object.keys(options).forEach((type) => {
-      options[type] === true ? defaults[type] : options[type]
+      options[type] = options[type] === true ? defaults[type] : options[type]
     })
 
     let emitHandler = this.emitHandler.bind(this)
@@ -92,7 +92,7 @@ module.exports = class Receiver extends EventEmitter {
     return app
   }
 
-  emitHandler (req, res, next) {
+  emitHandler (req, res) {
     let message = req.slackapp
 
     if (!message) {
@@ -108,19 +108,20 @@ module.exports = class Receiver extends EventEmitter {
     res.send()
   }
 
+  // TODO: extract log fns into an overridable logger
   logEvent (evt) {
     if (!evt) return console.log('Event: UNKNOWN')
     if (!evt.event) return console.log('Event: Missing:', evt)
-    let out = evt.event.user + ' -> ' + evt.event.type
+    let out = `${evt.event.user} -> ${evt.event.type}`
     switch (evt.event.type) {
       case 'reaction_added':
-        out += ' : ' + evt.event.item.type + '[' + evt.event.item.channel + ']' + ' : ' + evt.event.reaction
+        out += ` : ${evt.event.item.type} [${evt.event.item.channel}] : ${evt.event.reaction}`
         break
       case 'message':
         if (evt.event.subtype) {
-          out += ' : ' + evt.event.subtype + '[' + evt.event.channel + ']' + ' : ' + evt.event.text
+          out += ` : ${evt.event.subtype} [${evt.event.channel}] : ${evt.event.text}`
         } else {
-          out += ' : ' + evt.event.channel + ' : ' + evt.event.text
+          out += ` : ${evt.event.channel} : ${evt.event.text}`
         }
         break
     }
@@ -130,7 +131,7 @@ module.exports = class Receiver extends EventEmitter {
   logCommand (cmd) {
     if (!cmd) return console.log('Command: UNKNOWN')
     if (!cmd.command) return console.log('Command: Missing:', cmd)
-    console.log(cmd.user_id + ' -> ' + cmd.command + ' ' + cmd.text)
+    console.log(`${cmd.user_id} -> ${cmd.command} ${cmd.text}`)
   }
 
   logAction (action) {

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -1,15 +1,14 @@
 'use strict'
-// TODO: Move this file to src/receiver/index.js
 
 const EventEmitter = require('events')
 const fs = require('fs')
-const Message = require('./message')
-const ParseEvent = require('./receiver/middleware/parse-event')
-const ParseCommand = require('./receiver/middleware/parse-command')
-const ParseAction = require('./receiver/middleware/parse-action')
-const LookupTokens = require('./receiver/middleware/lookup-tokens')
-const VerifyToken = require('./receiver/middleware/verify-token')
-const SSLCheck = require('./receiver/middleware/ssl-check')
+const Message = require('../message')
+const ParseEvent = require('./middleware/parse-event')
+const ParseCommand = require('./middleware/parse-command')
+const ParseAction = require('./middleware/parse-action')
+const LookupTokens = require('./middleware/lookup-tokens')
+const VerifyToken = require('./middleware/verify-token')
+const SSLCheck = require('./middleware/ssl-check')
 
 /**
  * Receives HTTP requests with Events, Slash Commands, and Actions

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -10,7 +10,7 @@ module.exports = (options) => {
       return res.send(req.headers['bb-error'])
     }
 
-    if (!req.slackapp || !req.slackapp) {
+    if (!req.slackapp) {
       return res.send('Missing req.slackapp')
     }
 

--- a/src/receiver/middleware/lookup-tokens.js
+++ b/src/receiver/middleware/lookup-tokens.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// Enrich `req.slackapp.meta` with tokens and user ids parsed from Beep Boop headers
+module.exports = (options) => {
+  options = options || {}
+
+  return function tokenMiddleware (req, res, next) {
+    if (req.headers['bb-error']) {
+      console.error('Event: Error: ' + req.headers['bb-error'])
+      return res.send(req.headers['bb-error'])
+    }
+
+    if (!req.slackapp || !req.slackapp) {
+      return res.send('Missing req.slackapp')
+    }
+
+    req.slackapp.meta = Object.assign(req.slackapp.meta || {}, {
+      // token for the user for the app
+      app_token: req.headers['bb-slackaccesstoken'] || options.app_token,
+      // userID for the user who install ed the app
+      app_user_id: req.headers['bb-slackuserid'] || options.app_user_id,
+      // token for a bot user of the app
+      bot_token: req.headers['bb-slackbotaccesstoken'] || options.bot_token,
+      // userID of the bot user of the app
+      bot_user_id: req.headers['bb-slackbotuserid'] || options.bot_user_id
+    })
+
+    next()
+  }
+}

--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const bodyParser = require('body-parser')
+
+module.export = () => {
+  return [
+    bodyParser.json(),
+    (req, res, next) => {
+      let body = req.body
+
+      req.slackapp = {
+        type: 'action',
+        body: body,
+        meta: {
+          verify_token: body.token,
+          user_id: body.user.id,
+          channel_id: body.channel.id,
+          team_id: body.team.id
+        }
+      }
+    }
+  ]
+}

--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -2,11 +2,22 @@
 
 const bodyParser = require('body-parser')
 
-module.export = () => {
+module.exports = () => {
   return [
-    bodyParser.json(),
-    (req, res, next) => {
+    bodyParser.urlencoded({extended: true}),
+    bodyParser.text({type: '*/*'}),
+    function parseAction (req, res, next) {
       let body = req.body
+
+      if (!body || !body.payload) {
+        return res.send('Invalid request: payload missing')
+      }
+
+      try {
+        body = JSON.parse(body.payload)
+      } catch (e) {
+        return res.send('Error parsing payload')
+      }
 
       req.slackapp = {
         type: 'action',
@@ -18,6 +29,8 @@ module.export = () => {
           team_id: body.team.id
         }
       }
+
+      next()
     }
   ]
 }

--- a/src/receiver/middleware/parse-command.js
+++ b/src/receiver/middleware/parse-command.js
@@ -2,10 +2,10 @@
 
 const bodyParser = require('body-parser')
 
-module.export = () => {
+module.exports = () => {
   return [
     bodyParser.urlencoded({extended: true}),
-    (req, res, next) => {
+    function parseCommand (req, res, next) {
       let body = req.body
 
       req.slackapp = {
@@ -18,6 +18,8 @@ module.export = () => {
           team_id: body.team_id
         }
       }
+
+      next()
     }
   ]
 }

--- a/src/receiver/middleware/parse-command.js
+++ b/src/receiver/middleware/parse-command.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const bodyParser = require('body-parser')
+
+module.export = () => {
+  return [
+    bodyParser.urlencoded({extended: true}),
+    (req, res, next) => {
+      let body = req.body
+
+      req.slackapp = {
+        type: 'command',
+        body: body,
+        meta: {
+          verify_token: body.token,
+          user_id: body.user_id,
+          channel_id: body.channel_id,
+          team_id: body.team_id
+        }
+      }
+    }
+  ]
+}

--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -6,7 +6,7 @@ module.exports = () => {
   return [
     bodyParser.json(),
     function handleChallenge (req, res, next) {
-      let body = req.body
+      let body = req.body || {}
 
       // if this is a Slack challenge request, respond with the challenge and
       // don't emit the event
@@ -17,16 +17,17 @@ module.exports = () => {
       next()
     },
     function parseEvent (req, res, next) {
-      let body = req.body
+      let body = req.body || {}
+      let event = body.event || {}
 
       req.slackapp = {
         type: 'event',
         body: body,
         meta: {
           verify_token: body.token,
-          user_id: body.event.user,
-          bot_id: body.event.bot_id,
-          channel_id: body.event.channel,
+          user_id: event.user,
+          bot_id: event.bot_id,
+          channel_id: event.channel,
           team_id: body.team_id
         }
       }

--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const bodyParser = require('body-parser')
+
+module.export = () => {
+  return [
+    bodyParser.urlencoded({extended: true}),
+    bodyParser.text({type: '*/*'}),
+    function handleChallenge (req, res, next) {
+      let body = req.body
+
+      // if this is a Slack challenge request, respond with the challenge and
+      // don't emit the event
+      if (body.challenge) {
+        res.send({ challenge: body.challenge })
+        return
+      }
+    },
+    function parseEvent (req, res, next) {
+      let body = req.body
+
+      if (!body || !body.payload) {
+        return res.send('Invalid request: payload missing')
+      }
+
+      try {
+        body = JSON.parse(body.payload)
+      } catch (e) {
+        return res.send('Error parsing payload')
+      }
+
+      req.slackapp = {
+        type: 'event',
+        body: body,
+        meta: {
+          verify_token: body.token,
+          user_id: body.event.user,
+          bot_id: body.event.bot_id,
+          channel_id: body.event.channel,
+          team_id: body.team_id
+        }
+      }
+    }
+  ]
+}

--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -2,32 +2,22 @@
 
 const bodyParser = require('body-parser')
 
-module.export = () => {
+module.exports = () => {
   return [
-    bodyParser.urlencoded({extended: true}),
-    bodyParser.text({type: '*/*'}),
+    bodyParser.json(),
     function handleChallenge (req, res, next) {
       let body = req.body
 
       // if this is a Slack challenge request, respond with the challenge and
       // don't emit the event
       if (body.challenge) {
-        res.send({ challenge: body.challenge })
-        return
+        return res.send({ challenge: body.challenge })
       }
+
+      next()
     },
     function parseEvent (req, res, next) {
       let body = req.body
-
-      if (!body || !body.payload) {
-        return res.send('Invalid request: payload missing')
-      }
-
-      try {
-        body = JSON.parse(body.payload)
-      } catch (e) {
-        return res.send('Error parsing payload')
-      }
 
       req.slackapp = {
         type: 'event',
@@ -40,6 +30,8 @@ module.export = () => {
           team_id: body.team_id
         }
       }
+
+      next()
     }
   ]
 }

--- a/src/receiver/middleware/ssl-check.js
+++ b/src/receiver/middleware/ssl-check.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// if it's an `ssl_check` request, just respond w/ a 200
+module.exports = () => {
+  return function sslCheck (req, res, next) {
+    if (req.body && req.body.ssl_check) {
+      return res.send()
+    }
+
+    next()
+  }
+}

--- a/src/receiver/middleware/verify-token.js
+++ b/src/receiver/middleware/verify-token.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = (token) => {
+  return function verifyTokenMiddleware (req, res, next) {
+    // If token isn't set, we're not verifying
+    if (!token) {
+      return next()
+    }
+
+    let message = req.slackapp
+    let verifyToken = message && message.meta && message.meta.verify_token
+
+    // test verify token
+    if (token !== verifyToken) {
+      res.status(403).send('Invalid token')
+      return
+    }
+
+    next()
+  }
+}

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -206,16 +206,20 @@ class SlackApp {
    *
    * ##### Parameters
    * - `app` instance of Express app
+   * - `opts.event` `boolean` - add event route (defaults to `true`) [optional]
+   * - `opts.command` `boolean` - add command route (defaults to `true`) [optional]
+   * - `opts.action` `boolean` - add action route (defaults to `true`) [optional]
    *
    *
    * ##### Returns
    * - `app` reference to Express app passed in
    *
    * @param {Object} app - instance of Express app
+   * @param {Object} opts - options for attaching routes
    */
 
-  attachToExpress (app) {
-    return this.receiver.attachToExpress(app)
+  attachToExpress (app, opts) {
+    return this.receiver.attachToExpress(app, opts)
   }
 
   /**

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -21,6 +21,7 @@ class SlackApp {
    * - `opts.bot_token`   Slack App Bot token
    * - `opts.bot_user_id` Slack App Bot ID
    * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
+   * - `opts.tokens_lookup` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with tokens
    * - `opts.error`       Error handler function `(error) => {}`
    *
    * @api private
@@ -206,14 +207,29 @@ class SlackApp {
    *
    * ##### Parameters
    * - `app` instance of Express app
-   * - `opts.event` `boolean` - add event route (defaults to `true`) [optional]
-   * - `opts.command` `boolean` - add command route (defaults to `true`) [optional]
-   * - `opts.action` `boolean` - add action route (defaults to `true`) [optional]
+   * - `opts.event` `boolean|string` - event route (defaults to `/slackapp/event`) [optional]
+   * - `opts.command` `boolean|string` - command route (defaults to `/slackapp/command`) [optional]
+   * - `opts.action` `boolean|string` - action route (defaults to `/slackapp/action`) [optional]
    *
    *
    * ##### Returns
    * - `app` reference to Express app passed in
    *
+   * ```
+   * // would attach all routes w/ default paths
+   * slackapp.attachToExpress(app)
+   *
+   * slackapp.attachToExpress(app, {
+   *   event: true, // would register event route with default of /slackapp/event
+   *   command: false, // would not register a route for commands
+   *   action: '/slack-action' // custom route for actions
+   * })
+   *
+   * // would only attach a route for events w/ default path
+   * slackapp.attachToExpress(app, {
+   *   event: true
+   * })
+   * ````
    * @param {Object} app - instance of Express app
    * @param {Object} opts - options for attaching routes
    */

--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -2,7 +2,7 @@
 
 const slack = require('slack')
 const conversationStore = require('./conversation_store')
-const Receiver = require('./receiver')
+const Receiver = require('./receiver/')
 
 /**
  * A Slack App

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -2,6 +2,7 @@
 
 exports.getMockReq = function (req) {
   return Object.assign({
+    body: {},
     slackapp: {
       meta: {}
     }

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,27 @@
+'use strict'
+
+exports.getMockReq = function (req) {
+  return Object.assign({
+    slackapp: {
+      meta: {}
+    }
+  }, req || {})
+}
+
+exports.getMockRes = function (res) {
+  let mockRes = Object.assign({
+    send: () => {},
+    status: () => { return mockRes }
+  }, res || {})
+
+  return mockRes
+}
+
+exports.getMockHeaders = function (headers) {
+  return Object.assign({
+    'bb-slackaccesstoken': 'slackaccesstoken',
+    'bb-slackuserid': 'slackuserid',
+    'bb-slackbotaccesstoken': 'slackbotaccesstoken',
+    'bb-slackbotuserid': 'slackbotuserid'
+  }, headers || {})
+}

--- a/test/memory.convoStore.test.js
+++ b/test/memory.convoStore.test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const test = require('ava').test
+const Memory = require('../src/conversation_store/memory')
+
+test.cb('Memory() crud', t => {
+  t.plan(5)
+
+  let store = new Memory()
+  let id = 'convo_id'
+  let state = {
+    beep: 'boop'
+  }
+
+  store.set(id, state, () => {
+    store.get(id, (err, v) => {
+      t.is(err, null)
+      t.is(v.id, id)
+      t.is(v.beep, state.beep)
+
+      // Now delete and make sure it's gone
+      store.del(id, () => {
+        store.get(id, (err, v) => {
+          t.is(err, null)
+          t.is(v, null)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test.cb('Memory() set w/o callback', t => {
+  t.plan(3)
+
+  let store = new Memory()
+  let id = 'convo_id'
+  let state = {
+    beep: 'boop'
+  }
+
+  store.set(id, state)
+
+  store.get(id, (err, v) => {
+    t.is(err, null)
+    t.is(v.id, id)
+    t.is(v.beep, state.beep)
+    t.end()
+  })
+})
+
+test.cb('Memory() del w/o callback', t => {
+  t.plan(2)
+
+  let store = new Memory()
+  let id = 'convo_id'
+  let state = {
+    beep: 'boop'
+  }
+
+  // abusing the synchronous nature of the memory store for simpler tests ¯\_(ツ)_/¯
+  store.set(id, state)
+  store.del(id)
+
+  store.get(id, (err, v) => {
+    t.is(err, null)
+    t.is(v, null)
+    t.end()
+  })
+})
+
+test.cb('Memory() get expired', t => {
+  t.plan(2)
+
+  let store = new Memory()
+  let id = 'convo_id'
+  let state = {
+    beep: 'boop',
+    expiration: Date.now() - 1000
+  }
+
+  // set an expired value
+  store.set(id, state, () => {
+    store.get(id, (err, v) => {
+      t.is(err, null)
+      t.is(v, null)
+      t.end()
+    })
+  })
+})
+
+test.cb('Memory() get non expired', t => {
+  t.plan(3)
+
+  let store = new Memory()
+  let id = 'convo_id'
+  let state = {
+    beep: 'boop',
+    expiration: Date.now() + 10000
+  }
+
+  // set an expired value
+  store.set(id, state, () => {
+    store.get(id, (err, v) => {
+      t.is(err, null)
+      t.is(v.id, id)
+      t.is(v.beep, state.beep)
+      t.end()
+    })
+  })
+})

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -301,6 +301,22 @@ test.cb('Message.respond() w/ rate_limit error', t => {
   })
 })
 
+test('Message.respond() w/o callback', t => {
+  let msg = new Message()
+  let url = 'http://beepboophq.com'
+  let input = 'beepboop'
+
+  let reqStub = sinon.stub(msg, '_request', (responseUrl, input, cb) => {
+    t.is(responseUrl, url)
+    t.is(input, input)
+
+    cb(null, {}, { ok: true })
+  })
+
+  msg.respond(url, input)
+  t.true(reqStub.calledOnce)
+})
+
 test('Message.isMessage()', t => {
   let msg = new Message('event', {
     event: {

--- a/test/middleware.lookup-token.test.js
+++ b/test/middleware.lookup-token.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const LookupTokens = require('../src/receiver/middleware/lookup-tokens')
+
+test.cb('LookupToken()', t => {
+  t.plan(4)
+
+  let mw = LookupTokens()
+  let headers = fixtures.getMockHeaders()
+
+  let req = fixtures.getMockReq({ headers })
+  let res = fixtures.getMockRes()
+
+  mw(req, res, () => {
+    t.is(req.slackapp.meta.app_token, headers['bb-slackaccesstoken'])
+    t.is(req.slackapp.meta.app_user_id, headers['bb-slackuserid'])
+    t.is(req.slackapp.meta.bot_token, headers['bb-slackbotaccesstoken'])
+    t.is(req.slackapp.meta.bot_user_id, headers['bb-slackbotuserid'])
+    t.end()
+  })
+})
+
+test('LookupToken() error header', t => {
+  let mw = LookupTokens()
+  let headers = fixtures.getMockHeaders({
+    'bb-error': 'kaboom'
+  })
+
+  let req = fixtures.getMockReq({ headers })
+  let res = fixtures.getMockRes()
+
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(req, res, () => {
+    t.fail()
+  })
+
+  t.true(sendStub.calledOnce)
+})
+
+test('LookupToken() missing req.slackapp', t => {
+  let mw = LookupTokens()
+  let headers = fixtures.getMockHeaders()
+
+  let req = fixtures.getMockReq({ headers })
+  let res = fixtures.getMockRes()
+
+  delete req.slackapp
+
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(req, res, () => {
+    t.fail()
+  })
+
+  t.true(sendStub.calledOnce)
+})

--- a/test/middleware.parse-action.test.js
+++ b/test/middleware.parse-action.test.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const ParseAction = require('../src/receiver/middleware/parse-action')
+
+test('ParseAction()', t => {
+  let mw = ParseAction()
+  t.is(mw.length, 3)
+})

--- a/test/middleware.parse-action.test.js
+++ b/test/middleware.parse-action.test.js
@@ -9,3 +9,58 @@ test('ParseAction()', t => {
   let mw = ParseAction()
   t.is(mw.length, 3)
 })
+
+test('ParseAction() no payload', t => {
+  let mw = ParseAction().pop()
+
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  mw({ body: {} }, res, () => t.fail())
+  t.true(sendStub.calledWith('Invalid request: payload missing'))
+})
+
+test('ParseAction() invalid json payload', t => {
+  let mw = ParseAction().pop()
+
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  mw({ body: { payload: '\\{"' } }, res, () => t.fail())
+  t.true(sendStub.calledWith('Error parsing payload'))
+})
+
+test.cb('ParseAction() valid payload', t => {
+  t.plan(6)
+  let mw = ParseAction().pop()
+
+  let payload = mockPayload()
+  let req = { body: { payload: JSON.stringify(payload) } }
+
+  mw(req, fixtures.getMockRes(), () => {
+    let slackapp = req.slackapp
+
+    t.is(slackapp.type, 'action')
+    t.deepEqual(slackapp.body, payload)
+    t.is(slackapp.meta.verify_token, payload.token)
+    t.is(slackapp.meta.user_id, payload.user.id)
+    t.is(slackapp.meta.channel_id, payload.channel.id)
+    t.is(slackapp.meta.team_id, payload.team.id)
+    t.end()
+  })
+})
+
+function mockPayload () {
+  return {
+    token: 'token',
+    user: {
+      id: 'user_id'
+    },
+    channel: {
+      id: 'channel_id'
+    },
+    team: {
+      id: 'team_id'
+    }
+  }
+}

--- a/test/middleware.parse-command.test.js
+++ b/test/middleware.parse-command.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const test = require('ava').test
+const ParseCommand = require('../src/receiver/middleware/parse-command')
+
+test('ParseCommand()', t => {
+  let mw = ParseCommand()
+  t.is(mw.length, 2)
+})
+
+test.cb('ParseCommand() no payload', t => {
+  let mw = ParseCommand().pop()
+  let req = { body: {} }
+
+  mw(req, {}, () => {
+    let slackapp = req.slackapp
+
+    t.is(slackapp.type, 'command')
+    t.deepEqual(slackapp.body, req.body)
+    t.is(slackapp.meta.verify_token, undefined)
+    t.is(slackapp.meta.user_id, undefined)
+    t.is(slackapp.meta.channel_id, undefined)
+    t.is(slackapp.meta.team_id, undefined)
+    t.end()
+  })
+})
+
+test.cb('ParseCommand() with payload', t => {
+  let mw = ParseCommand().pop()
+  let payload = mockPayload()
+  let req = { body: payload }
+
+  mw(req, {}, () => {
+    let slackapp = req.slackapp
+
+    t.is(slackapp.type, 'command')
+    t.deepEqual(slackapp.body, req.body)
+    t.is(slackapp.meta.verify_token, payload.token)
+    t.is(slackapp.meta.user_id, payload.user_id)
+    t.is(slackapp.meta.channel_id, payload.channel_id)
+    t.is(slackapp.meta.team_id, payload.team_id)
+    t.end()
+  })
+})
+
+function mockPayload () {
+  return {
+    token: 'token',
+    user_id: 'user_id',
+    channel_id: 'channel_id',
+    team_id: 'team_id'
+  }
+}

--- a/test/middleware.parse-event.test.js
+++ b/test/middleware.parse-event.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const ParseEvent = require('../src/receiver/middleware/parse-event')
+
+test('ParseEvent()', t => {
+  let mw = ParseEvent()
+  t.is(mw.length, 3)
+})
+
+test.cb('ParseEvent() no payload', t => {
+  let mw = ParseEvent().pop()
+  let req = { body: {} }
+
+  mw(req, {}, () => {
+    let slackapp = req.slackapp
+
+    t.is(slackapp.type, 'event')
+    t.deepEqual(slackapp.body, req.body)
+    t.is(slackapp.meta.verify_token, undefined)
+    t.is(slackapp.meta.user_id, undefined)
+    t.is(slackapp.meta.bot_id, undefined)
+    t.is(slackapp.meta.channel_id, undefined)
+    t.is(slackapp.meta.team_id, undefined)
+    t.end()
+  })
+})
+
+test.cb('ParseEvent() with payload', t => {
+  let mw = ParseEvent().pop()
+  let payload = mockPayload()
+  let req = { body: payload }
+
+  mw(req, {}, () => {
+    let slackapp = req.slackapp
+
+    t.is(slackapp.type, 'event')
+    t.deepEqual(slackapp.body, req.body)
+    t.is(slackapp.meta.verify_token, payload.token)
+    t.is(slackapp.meta.user_id, payload.event.user)
+    t.is(slackapp.meta.bot_id, payload.event.bot_id)
+    t.is(slackapp.meta.channel_id, payload.event.channel)
+    t.is(slackapp.meta.team_id, payload.team_id)
+    t.end()
+  })
+})
+
+test('ParseEvent() challenge request', t => {
+  let mw = ParseEvent()[1]
+
+  let req = { body: { challenge: 'challenge' } }
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(req, res, () => t.fail())
+  t.true(sendStub.calledWith({ challenge: req.body.challenge }))
+})
+
+test.cb('ParseEvent() non-challenge request', t => {
+  let mw = ParseEvent()[1]
+
+  mw({}, {}, () => {
+    t.pass()
+    t.end()
+  })
+})
+
+function mockPayload () {
+  return {
+    token: 'token',
+    event: {
+      user: 'user_id',
+      bot_id: 'bot_id',
+      channel: 'channel_id'
+    },
+    team_id: 'team_id'
+  }
+}

--- a/test/middleware.ssl-check.test.js
+++ b/test/middleware.ssl-check.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const SSLCheck = require('../src/receiver/middleware/ssl-check')
+
+test.cb('SSLCheck() no ssl_check', t => {
+  let mw = SSLCheck()
+  mw({ body: {} }, {}, () => {
+    t.pass()
+    t.end()
+  })
+})
+
+test('SSLCheck() no ssl_check', t => {
+  let mw = SSLCheck()
+  let res = fixtures.getMockRes()
+
+  let sendStub = sinon.stub(res, 'send')
+
+  mw({ body: { ssl_check: true } }, res, () => {})
+  t.true(sendStub.calledOnce)
+})

--- a/test/middleware.verify-token.test.js
+++ b/test/middleware.verify-token.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const VerifyToken = require('../src/receiver/middleware/verify-token')
+
+test.cb('VerifyToken() no token option', t => {
+  let mw = VerifyToken()
+
+  mw(fixtures.getMockReq(), fixtures.getMockRes(), () => {
+    t.pass()
+    t.end()
+  })
+})
+
+test('VerifyToken() token option no verify_token', t => {
+  let mw = VerifyToken('beepboop')
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(fixtures.getMockReq(), res, () => {})
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid token'))
+})
+
+test.cb('VerifyToken() token option matching verify_token', t => {
+  let token = 'beepboop'
+  let mw = VerifyToken(token)
+  let req = fixtures.getMockReq({
+    slackapp: {
+      meta: {
+        verify_token: token
+      }
+    }
+  })
+  let res = fixtures.getMockRes()
+
+  mw(req, res, () => {
+    t.pass()
+    t.end()
+  })
+})
+
+test('VerifyToken() token option matching verify_token', t => {
+  let token = 'beepboop'
+  let mw = VerifyToken(token)
+  let req = fixtures.getMockReq({
+    slackapp: {
+      meta: {
+        verify_token: 'derp'
+      }
+    }
+  })
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(req, res, () => {})
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid token'))
+})

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -10,7 +10,7 @@ test('Receiver() w/ record', t => {
   let appendStub = sinon.stub(fs, 'appendFile', () => {})
 
   let rec = new Receiver({
-    record: true
+    record: 'slack-events.log'
   })
 
   t.true(writeStub.calledOnce)

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -3,19 +3,304 @@
 const test = require('ava').test
 const sinon = require('sinon')
 const fs = require('fs')
-const Receiver = require('../src/receiver')
+const fixtures = require('./fixtures/')
+const Receiver = require('../src/receiver/')
 
 test('Receiver() w/ record', t => {
   let writeStub = sinon.stub(fs, 'writeFileSync', () => {})
   let appendStub = sinon.stub(fs, 'appendFile', () => {})
 
-  let rec = new Receiver({
+  let receiver = new Receiver({
     record: 'slack-events.log'
   })
 
   t.true(writeStub.calledOnce)
 
-  rec.emit('message', {})
+  receiver.emit('message', {})
 
   t.true(appendStub.calledOnce)
+  fs.writeFileSync.restore()
+  fs.appendFile.restore()
 })
+
+test('Receiver.attachToExpress() defaults', t => {
+  let receiver = new Receiver()
+
+  let app = {
+    post: () => {}
+  }
+  let appStub = sinon.stub(app, 'post')
+
+  receiver.attachToExpress(app)
+
+  t.true(appStub.calledThrice)
+  t.true(appStub.calledWith('/slackapp/event'))
+  t.true(appStub.calledWith('/slackapp/command'))
+  t.true(appStub.calledWith('/slackapp/action'))
+})
+
+test('Receiver.attachToExpress() true, false, string', t => {
+  let receiver = new Receiver()
+  let actionRoute = '/slack-action'
+
+  let app = {
+    post: () => {}
+  }
+  let appStub = sinon.stub(app, 'post')
+
+  receiver.attachToExpress(app, {
+    event: true,
+    command: false,
+    action: actionRoute
+  })
+
+  t.true(appStub.calledTwice)
+  t.true(appStub.calledWith('/slackapp/event'))
+  t.true(appStub.calledWith(actionRoute))
+})
+
+test('Receiver.emitHandler() no req.slackapp', t => {
+  let receiver = new Receiver()
+
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  receiver.emitHandler({}, res, () => t.fail())
+  t.true(sendStub.calledWith('Missing req.slackapp'))
+})
+
+test('Receiver.emitHandler() w/ debug', t => {
+  let receiver = new Receiver({
+    debug: true
+  })
+  let msg = getMockMessage()
+  let res = fixtures.getMockRes()
+
+  let logStub = sinon.stub(receiver.logfn, msg.type)
+  let emitStub = sinon.stub(receiver, 'emit')
+  let sendStub = sinon.stub(res, 'send')
+
+  receiver.emitHandler({ slackapp: msg }, res, () => t.fail())
+
+  t.true(logStub.calledOnce)
+  t.deepEqual(logStub.getCall(0).args[0], msg.body)
+  t.true(emitStub.calledOnce)
+  t.true(sendStub.calledOnce)
+})
+
+test('Receiver.emitHandler() w/o debug', t => {
+  let receiver = new Receiver()
+  let msg = getMockMessage()
+  let res = fixtures.getMockRes()
+
+  let logStub = sinon.stub(receiver.logfn, msg.type)
+  let emitStub = sinon.stub(receiver, 'emit')
+  let sendStub = sinon.stub(res, 'send')
+
+  receiver.emitHandler({ slackapp: msg }, res, () => t.fail())
+
+  t.false(logStub.calledOnce)
+  t.true(emitStub.calledOnce)
+  t.true(sendStub.calledOnce)
+})
+
+test('Receiver.logCommand() no command', t => {
+  let receiver = new Receiver()
+
+  let logStub = sinon.stub(console, 'log')
+  receiver.logCommand()
+
+  t.true(logStub.calledWith('Command: UNKNOWN'))
+
+  console.log.restore()
+})
+
+test('Receiver.logCommand() no command prop', t => {
+  let receiver = new Receiver()
+  let cmd = {}
+  let logStub = sinon.stub(console, 'log')
+
+  receiver.logCommand(cmd)
+
+  t.true(logStub.calledWith('Command: Missing:', cmd))
+
+  console.log.restore()
+})
+
+test('Receiver.logCommand()', t => {
+  let receiver = new Receiver()
+  let cmd = {
+    command: 'beepboop',
+    user_id: 'user_id',
+    text: 'allthebots'
+  }
+  let logStub = sinon.stub(console, 'log')
+
+  receiver.logCommand(cmd)
+
+  let text = logStub.getCall(0).args[0]
+  t.true(text.indexOf(cmd.command) >= 0)
+  t.true(text.indexOf(cmd.user_id) >= 0)
+  t.true(text.indexOf(cmd.text) >= 0)
+
+  console.log.restore()
+})
+
+test('Receiver.logAction() no action', t => {
+  let receiver = new Receiver()
+
+  let logStub = sinon.stub(console, 'log')
+  receiver.logAction()
+
+  t.true(logStub.calledWith('Action: UNKNOWN'))
+
+  console.log.restore()
+})
+
+test('Receiver.logAction()', t => {
+  let receiver = new Receiver()
+  let action = {
+    'beep': 'boop'
+  }
+  let logStub = sinon.stub(console, 'log')
+
+  receiver.logAction(action)
+
+  t.true(logStub.calledWith('Action:', action))
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() no event', t => {
+  let receiver = new Receiver()
+
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent()
+
+  t.true(logStub.calledWith('Event: UNKNOWN'))
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() no event prop', t => {
+  let receiver = new Receiver()
+  let event = {}
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent(event)
+
+  t.true(logStub.calledWith('Event: Missing:', event))
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() unspecified type', t => {
+  let receiver = new Receiver()
+  let event = {
+    event: {
+      type: 'beepboop',
+      user: 'user'
+    }
+  }
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent(event)
+
+  let text = logStub.getCall(0).args[0]
+  t.true(text.indexOf(event.event.type) >= 0)
+  t.true(text.indexOf(event.event.user) >= 0)
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() reaction_added', t => {
+  let receiver = new Receiver()
+  let event = {
+    event: {
+      type: 'reaction_added',
+      user: 'user',
+      item: {
+        type: 'item_type',
+        channel: 'item_channel'
+      },
+      reaction: 'reaction'
+    }
+  }
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent(event)
+
+  let text = logStub.getCall(0).args[0]
+  t.true(text.indexOf(event.event.type) >= 0)
+  t.true(text.indexOf(event.event.user) >= 0)
+  t.true(text.indexOf(event.event.item.type) >= 0)
+  t.true(text.indexOf(event.event.item.channel) >= 0)
+  t.true(text.indexOf(event.event.reaction) >= 0)
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() message', t => {
+  let receiver = new Receiver()
+  let event = {
+    event: {
+      type: 'message',
+      user: 'user',
+      channel: 'channel',
+      text: 'event text'
+    }
+  }
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent(event)
+
+  let text = logStub.getCall(0).args[0]
+  t.true(text.indexOf(event.event.type) >= 0)
+  t.true(text.indexOf(event.event.user) >= 0)
+  t.true(text.indexOf(event.event.channel) >= 0)
+  t.true(text.indexOf(event.event.text) >= 0)
+
+  console.log.restore()
+})
+
+test('Receiver.logEvent() message w/ subtype', t => {
+  let receiver = new Receiver()
+  let event = {
+    event: {
+      type: 'message',
+      subtype: 'sub-type',
+      user: 'user',
+      channel: 'channel',
+      text: 'event text'
+    }
+  }
+  let logStub = sinon.stub(console, 'log')
+  receiver.logEvent(event)
+
+  let text = logStub.getCall(0).args[0]
+  t.true(text.indexOf(event.event.type) >= 0)
+  t.true(text.indexOf(event.event.subtype) >= 0)
+  t.true(text.indexOf(event.event.user) >= 0)
+  t.true(text.indexOf(event.event.channel) >= 0)
+  t.true(text.indexOf(event.event.text) >= 0)
+
+  console.log.restore()
+})
+
+function getMockMessage () {
+  return {
+    type: 'event',
+    body: {
+      token: 'token',
+      event: {
+        user: 'user_id',
+        bot_id: 'bot_id',
+        channel: 'channel_id'
+      },
+      team_id: 'team_id'
+    },
+    meta: {
+      verify_token: 'verify_token',
+      user_id: 'user_id',
+      bot_id: 'bot_id',
+      channel_id: 'channel_id',
+      team_id: 'team_id'
+    }
+  }
+}

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fs = require('fs')
+const Receiver = require('../src/receiver')
+
+test('Receiver() w/ record', t => {
+  let writeStub = sinon.stub(fs, 'writeFileSync', () => {})
+  let appendStub = sinon.stub(fs, 'appendFile', () => {})
+
+  let rec = new Receiver({
+    record: true
+  })
+
+  t.true(writeStub.calledOnce)
+
+  rec.emit('message', {})
+
+  t.true(appendStub.calledOnce)
+})


### PR DESCRIPTION
+ Refactors the `Receiver` class so you can pass in a `tokens_lookup` option that is an http mw function for enriching the `req.slackapp.meta` with necessary oauth tokens/ids

+ Adds _a lot_ of tests, 💯  coverage across everything
+ Adds enforcement of `95%` statements coverage for build